### PR TITLE
Fix a bug for updating objective_perf in CNNFinalTrainer.

### DIFF
--- a/aw_nas/final/cnn_trainer.py
+++ b/aw_nas/final/cnn_trainer.py
@@ -381,10 +381,10 @@ class CNNFinalTrainer(FinalTrainer): #pylint: disable=too-many-instance-attribut
 
                 logits = model(inputs)
                 loss = criterion(logits, target)
-                perfs = self._perf_func(inputs, logits, target, model)
-                objective_perfs.update(dict(zip(self._perf_names, perfs)))
-                prec1, prec5 = utils.accuracy(logits, target, topk=(1, 5))
                 n = inputs.size(0)
+                perfs = self._perf_func(inputs, logits, target, model)
+                objective_perfs.update(dict(zip(self._perf_names, perfs)), n)
+                prec1, prec5 = utils.accuracy(logits, target, topk=(1, 5))
                 objs.update(loss.item(), n)
                 top1.update(prec1.item(), n)
                 top5.update(prec5.item(), n)

--- a/aw_nas/utils/common_utils.py
+++ b/aw_nas/utils/common_utils.py
@@ -182,10 +182,10 @@ class OrderedStats(object):
 
     __bool__ = __nonzero__
 
-    def update(self, stats):
+    def update(self, stats, n=1):
         if self.stat_meters is None:
-            self.stat_meters = OrderedDict([(n, AverageMeter()) for n in stats])
-        [self.stat_meters[n].update(v) for n, v in stats.items()]
+            self.stat_meters = OrderedDict([(name, AverageMeter()) for name in stats])
+        [self.stat_meters[name].update(v, n) for name, v in stats.items()]
 
     def avgs(self):
         if self.stat_meters is None:


### PR DESCRIPTION
While inferring,  the last batch may have a smaller batch size than others. Therefore, total perf shouldn't be the average of perfs of all batches.