### PR TITLE
init kernel transform with eye matrix and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea/
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/aw_nas/objective/ofa.py
+++ b/aw_nas/objective/ofa.py
@@ -127,10 +127,11 @@ class OFAClassificationObjective(BaseObjective):
         loss = self._criterion(outputs, targets)
         if self.soft_loss_coeff > 0 and not self.is_finetune:
             # do not calculate soft loss during finetuning
-            outputs_all = cand_net.super_net.forward(inputs).detach()
-            soft = self.loss_soft(outputs, outputs_all, self.soft_loss_coeff)
-            loss2 = loss + soft * self.soft_loss_coeff
-            return loss2
+            with torch.no_grad():
+                outputs_all = cand_net.super_net.forward(inputs).detach()
+                soft = self.loss_soft(outputs, outputs_all, self.soft_loss_coeff)
+                loss2 = loss + soft * self.soft_loss_coeff
+                return loss2
         return loss
 
     def on_epoch_start(self, epoch):

--- a/aw_nas/utils/common_utils.py
+++ b/aw_nas/utils/common_utils.py
@@ -486,11 +486,10 @@ def get_sub_kernel(kernel, sub_kernel_size):
     right = center + width + 1
     return kernel[:, :, left:right, left:right].contiguous()
 
-def _get_channel_mask(filters, num_channels):
-    norm_tensor = np.abs(filters.cpu().detach().numpy()).sum(axis=3).sum(axis=2).sum(axis=0)
-    norm_tensor = sorted(zip(range(len(norm_tensor)), norm_tensor),
-                         key=lambda x: x[1], reverse=True)
-    channel_order = [x[0] for x in norm_tensor]
+
+def _get_channel_mask(filters: torch.Tensor, num_channels):
+    norm_tensor = torch.norm(filters, p=1, dim=(0, 2, 3))
+    channel_order = torch.argsort(norm_tensor, descending=True)
     mask = np.zeros(filters.shape[1], dtype=np.bool)
     reserved_channels = channel_order[:num_channels]
     mask[reserved_channels] = 1


### PR DESCRIPTION
- init kernel transform with eye matrix;
- sort channel importance with torch to fix latency;
- fix missing no_grad() when using OFA soft_loss;
- fix typo